### PR TITLE
Textrenderer

### DIFF
--- a/compiler/src/edu/clemson/resolve/parser/Resolve.g4
+++ b/compiler/src/edu/clemson/resolve/parser/Resolve.g4
@@ -491,7 +491,7 @@ mathTupleExp
     ;
 
 mathSegmentsExp
-    :   mathFunctionApplicationExp (DOT mathFunctionApplicationExp)+
+    :   (AT)? mathFunctionApplicationExp (DOT mathFunctionApplicationExp)+
     ;
 
 mathFunctionRestrictionExp

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PAlternatives.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PAlternatives.java
@@ -40,15 +40,13 @@ public class PAlternatives extends PExp {
 
         boolean first = true;
         for (Alternative alt : alternatives) {
-            if ( !first ) {
+            if (!first) {
                 v.fencepostPAlternatives(this);
             }
-
             alt.result.accept(v);
             alt.condition.accept(v);
         }
         v.fencepostPAlternatives(this);
-
         otherwiseClauseResult.accept(v);
         v.endChildren(this);
         v.endPAlternatives(this);

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PExp.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PExp.java
@@ -1,12 +1,9 @@
 package edu.clemson.resolve.proving.absyn;
 
 import org.rsrg.semantics.MTType;
-import org.rsrg.semantics.TypeGraph;
 import org.rsrg.semantics.programtype.PTType;
 
-import java.io.StringWriter;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class PExp {
 
@@ -108,11 +105,18 @@ public abstract class PExp {
     }
 
     public void processStringRepresentation(PExpVisitor visitor, Appendable a) {
+        throw new UnsupportedOperationException("not yet supported");
         //PExpTextRenderingVisitor renderer = new PExpTextRenderingVisitor(a);
          //PExpVisitor finalVisitor = new NestedPExpVisitors(visitor, renderer);
          //this.accept(finalVisitor);
         //this.accept(renderer);
+    }
 
+    public String getText() {
+        StringBuilder sb = new StringBuilder();
+        PExpTextRenderingVisitor renderer = new PExpTextRenderingVisitor(sb);
+        this.accept(renderer);
+        return sb.toString();
     }
 
     public boolean typeMatches(MTType other) {

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PExpBuildingListener.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PExpBuildingListener.java
@@ -195,7 +195,9 @@ public class PExpBuildingListener<T extends PExp> extends ResolveBaseListener {
 
         String name = Utils.join(nameComponents, ".");
         PSymbolBuilder result = new PSymbolBuilder(name).arguments(
-                last.getArguments()).mathType(last.getMathType());
+                last.getArguments()).incoming(ctx.AT() != null)
+                .mathType(last.getMathType());
+
         repo.put(ctx, result.build());
     }
 

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PExpTextRenderingVisitor.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PExpTextRenderingVisitor.java
@@ -1,0 +1,198 @@
+package edu.clemson.resolve.proving.absyn;
+
+import java.io.IOException;
+
+public class PExpTextRenderingVisitor extends PExpVisitor {
+
+    private final Appendable output;
+
+    private PAlternatives encounteredAlternative;
+    private PExp encounteredResult;
+
+    public PExpTextRenderingVisitor(Appendable w) {
+        output = w;
+    }
+
+    @Override public void beginPExp(PExp p) {
+        if (encounteredAlternative != null) {
+            if (encounteredResult == null) {
+                encounteredResult = p;
+            }
+            else {
+                try {
+                    encounteredResult = null;
+                    output.append(", if ");
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @Override public void beginPrefixPSymbol(PSymbol p) {
+        try {
+            output.append(p.getName());
+
+            if (p.getArguments().size() > 0) {
+                output.append("(");
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void beginInfixPSymbol(PSymbol p) {
+        try {
+            output.append("(");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void beginOutfixPSymbol(PSymbol p) {
+        try {
+            output.append(p.getLeftPrint());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void beginPostfixPSymbol(PSymbol p) {
+        try {
+            if (p.getArguments().size() > 0) {
+                output.append("(");
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void beginPAlternatives(PAlternatives p) {
+        try {
+            output.append("{");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void beginPLambda(PLambda l) {
+        try {
+            output.append("lambda (");
+            boolean first = true;
+            for (PLambda.Parameter p : l.getParameters()) {
+                if (first) {
+                    first = false;
+                }
+                else {
+                    output.append(", ");
+                }
+                output.append("" + p);
+            }
+            output.append(").");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void fencepostPrefixPSymbol(PSymbol p) {
+        try {
+            output.append(", ");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void fencepostInfixPSymbol(PSymbol p) {
+        try {
+            output.append(" " + p.getName() + " ");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void fencepostOutfixPSymbol(PSymbol p) {
+        try {
+            output.append(", ");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void fencepostPostfixPSymbol(PSymbol p) {
+        try {
+            output.append(", ");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void fencepostPAlternatives(PAlternatives p) {
+        try {
+            output.append("; ");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void endPrefixPSymbol(PSymbol p) {
+        try {
+            if (p.getArguments().size() > 0) {
+                output.append(")");
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void endInfixPSymbol(PSymbol p) {
+        try {
+            output.append(")");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void endOutfixPSymbol(PSymbol p) {
+        try {
+            output.append(p.getRightPrint());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void endPostfixPSymbol(PSymbol p) {
+        try {
+            if (p.getArguments().size() > 0) {
+                output.append(")");
+            }
+            output.append(p.getName());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public void endPAlternatives(PAlternatives p) {
+        try {
+            output.append(", otherwise}");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PExpVisitor.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PExpVisitor.java
@@ -4,17 +4,35 @@ public abstract class PExpVisitor {
 
     public void beginPExp(PExp p) {}
 
+    public void beginPSet(PSet p) {}
+
     public void beginPSymbol(PSymbol p) {}
 
-    public void beginPAlternatives(PAlternatives p) {}
+    public void beginPrefixPSymbol(PSymbol p) {}
 
-    public void beginPSet(PSet p) {}
+    public void beginInfixPSymbol(PSymbol p) {}
+
+    public void beginOutfixPSymbol(PSymbol p) {}
+
+    public void beginPostfixPSymbol(PSymbol p) {}
+
+    public void beginPAlternatives(PAlternatives p) {}
 
     public void beginPLambda(PLambda p) {}
 
     public void beginChildren(PExp p) {}
 
+    public void fencepostPSet(PSet p) {}
+
     public void fencepostPSymbol(PSymbol p) {}
+
+    public void fencepostPrefixPSymbol(PSymbol p) {}
+
+    public void fencepostInfixPSymbol(PSymbol p) {}
+
+    public void fencepostOutfixPSymbol(PSymbol p) {}
+
+    public void fencepostPostfixPSymbol(PSymbol p) {}
 
     public void fencepostPAlternatives(PAlternatives p) {}
 
@@ -24,10 +42,18 @@ public abstract class PExpVisitor {
 
     public void endPSymbol(PSymbol p) {}
 
+    public void endPrefixPSymbol(PSymbol p) {}
+
+    public void endInfixPSymbol(PSymbol p) {}
+
+    public void endOutfixPSymbol(PSymbol p) {}
+
+    public void endPostfixPSymbol(PSymbol p) {}
+
     public void endPAlternatives(PAlternatives p) {}
 
-    public void endPLambda(PLambda p) {}
-
     public void endPSet(PSet p) {}
+
+    public void endPLambda(PLambda p) {}
 
 }

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PSet.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PSet.java
@@ -18,13 +18,17 @@ public class PSet extends PExp {
     @Override public void accept(PExpVisitor v) {
         v.beginPExp(this);
         v.beginPSet(this);
-
         v.beginChildren(this);
+        boolean first = true;
+
         for (PExp e : elements) {
+            if (!first) {
+                v.fencepostPSet(this);
+            }
+            first = false;
             e.accept(v);
         }
         v.endChildren(this);
-
         v.endPSet(this);
         v.endPExp(this);
     }

--- a/compiler/test/edu/clemson/resolve/TestPExpVisitor.java
+++ b/compiler/test/edu/clemson/resolve/TestPExpVisitor.java
@@ -34,8 +34,13 @@ public class TestPExpVisitor extends BaseTest {
             "<PSymbol:end>:(x + (1 * y))\n"
         };
         PExp tree = TestPExp.parseMathAssertionExp(g, "x + 1 * y");
+        PExp e = TestPExp.parseMathAssertionExp(g, "(((1 <= Max_Depth) implies  ((|S| <= Max_Depth) implies  (Temp = Empty_String implies S = (Reverse(Temp) o S)))) and  ((1 <= Max_Depth) implies  ((|S| <= Max_Depth) implies  (S = (Reverse(Temp_p) o S_p) implies  (not((1 <= |S_p|)) implies  Temp_p = Reverse(S))))))");//and " +
+        PExp spiral_text = TestPExp.parseMathAssertionExp(g, "P.Trmnl_Loc = SS(k)(0, @P.Trmnl_Loc) and P.Curr_Loc = @P.Curr_Loc and P.Lab = lambda (q : Sp_Loc(k)).({{@e if q = @P.Trmnl_Loc; @P.Lab(q) otherwise;}})");
+
         DemoVisitor v = new DemoVisitor();
         tree.accept(v);
+        //Todo: Add @ incoming printing to PExpTextRenderingVisitor
+        System.out.println(spiral_text.getText() + "\n" + spiral_text.toString());
         Assert.assertEquals(expected[0], v.trace);
     }
 

--- a/compiler/workspace/T_I.resolve
+++ b/compiler/workspace/T_I.resolve
@@ -1,7 +1,7 @@
 Implementation T_I(Operation P(alters j,k : U ) : Std_Boolean_Fac :: Boolean;) for T;
         uses Standard_Booleans, Standard_Char_Strings;
-    Procedure Op(evaluates i, j : U);
-        If P(i, j) then
+    Procedure Op(evaluates i,j : U);
+        If P( i,j ) then
             Std_Char_Str_Fac :: Write_Line("P=true");
         else
             Std_Char_Str_Fac :: Write_Line("P=false");

--- a/compiler/workspace/Writing_Capability.resolve
+++ b/compiler/workspace/Writing_Capability.resolve
@@ -1,3 +1,4 @@
 Enhancement Writing_Capability for Bdd_Stack_Template;
+
 	Operation Write(clears S : Stack);
 end Writing_Capability;


### PR DESCRIPTION
Some adjustments/tweaks to the PExp visitor. Specifically, adds separate methods for infix, outfix, prefix, etc `PSymbol`s.  Also adds a text renderer that prints the tree via the visitor.