### PR TITLE
Fixes2

### DIFF
--- a/compiler/src/edu/clemson/resolve/analysis/AnalysisPipeline.java
+++ b/compiler/src/edu/clemson/resolve/analysis/AnalysisPipeline.java
@@ -28,9 +28,9 @@ public class AnalysisPipeline extends AbstractCompilationPipeline {
             PExpBuildingListener<PExp> pexpAnnotator =
                     new PExpBuildingListener<>(compiler.symbolTable.mathPExps,
                             unit);
-            //SanityChecker sanityChecker = new SanityChecker(compiler, unit);
-
-            //walker.walk(sanityChecker, unit.getRoot());
+            SanityCheckingListener sanityChecker =
+                    new SanityCheckingListener(compiler, unit);
+            walker.walk(sanityChecker, unit.getRoot());
             if ( compiler.errMgr.getErrorCount() > 0 ) return;
             walker.walk(pexpAnnotator, unit.getRoot());
             unit.mathPExps = compiler.symbolTable.mathPExps;

--- a/compiler/src/edu/clemson/resolve/analysis/AnalysisPipeline.java
+++ b/compiler/src/edu/clemson/resolve/analysis/AnalysisPipeline.java
@@ -30,10 +30,10 @@ public class AnalysisPipeline extends AbstractCompilationPipeline {
                             unit);
             SanityCheckingListener sanityChecker =
                     new SanityCheckingListener(compiler, unit);
-            walker.walk(sanityChecker, unit.getRoot());
-            if ( compiler.errMgr.getErrorCount() > 0 ) return;
             walker.walk(pexpAnnotator, unit.getRoot());
             unit.mathPExps = compiler.symbolTable.mathPExps;
+            walker.walk(sanityChecker, unit.getRoot());
+            if ( compiler.errMgr.getErrorCount() > 0 ) return;
         }
     }
 }

--- a/compiler/src/edu/clemson/resolve/analysis/PopulatingVisitor.java
+++ b/compiler/src/edu/clemson/resolve/analysis/PopulatingVisitor.java
@@ -897,6 +897,13 @@ public class PopulatingVisitor extends ResolveBaseVisitor<Void> {
         return null;
     }
 
+    @Override public Void visitProgVarExp(Resolve.ProgVarExpContext ctx) {
+        this.visit(ctx.getChild(0));
+        tr.progTypes.put(ctx, tr.progTypes.get(ctx.getChild(0)));
+        tr.mathTypes.put(ctx, tr.mathTypes.get(ctx.getChild(0)));
+        return null;
+    }
+
     @Override public Void visitProgNamedExp(Resolve.ProgNamedExpContext ctx) {
         try {
             ProgVariableSymbol variable =

--- a/compiler/src/edu/clemson/resolve/analysis/PopulatingVisitor.java
+++ b/compiler/src/edu/clemson/resolve/analysis/PopulatingVisitor.java
@@ -1104,11 +1104,6 @@ public class PopulatingVisitor extends ResolveBaseVisitor<Void> {
                     PTVoid.getInstance(g);
             tr.progTypes.put(ctx, t);
             tr.mathTypes.put(ctx, t.toMath());
-            if (currentOpProcedureDecl.recursive == null) {
-                compiler.errMgr.semanticError(
-                        ErrorKind.UNMARKED_RECURSIVE_CALL, name, ctx.getText(),
-                        name.getText());
-            }
             return;
         }
         try {

--- a/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
+++ b/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
@@ -8,6 +8,8 @@ import edu.clemson.resolve.parser.ResolveBaseListener;
 import edu.clemson.resolve.parser.ResolveBaseVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.RuleNode;
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.rsrg.semantics.programtype.PTType;
 
 /** Uses a combination of listeners and visitors to check for some semantic
@@ -63,7 +65,11 @@ public class SanityCheckingListener extends ResolveBaseListener {
     }
 
     @Override public void exitAssignStmt(Resolve.AssignStmtContext ctx) {
-        //TODO: Also check that lhs is a variable based expr.
+        sanityCheckProgOpTypes(ctx, tr.progTypes.get(ctx.left),
+                tr.progTypes.get(ctx.right));
+    }
+
+    @Override public void exitSwapStmt(Resolve.SwapStmtContext ctx) {
         sanityCheckProgOpTypes(ctx,tr.progTypes.get(ctx.left),
                 tr.progTypes.get(ctx.right));
     }
@@ -114,6 +120,9 @@ public class SanityCheckingListener extends ResolveBaseListener {
             @Override public Boolean visitProgParamExp(
                     Resolve.ProgParamExpContext paramExp) {
                 return paramExp.name.getText().equals(name.getText());
+            }
+            @Override public Boolean visitTerminal(TerminalNode var1) {
+                return false;
             }
         }.visit(ctx);
     }

--- a/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
+++ b/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
@@ -1,6 +1,110 @@
 package edu.clemson.resolve.analysis;
 
+import edu.clemson.resolve.compiler.AnnotatedTree;
+import edu.clemson.resolve.compiler.ErrorKind;
+import edu.clemson.resolve.compiler.RESOLVECompiler;
+import edu.clemson.resolve.parser.Resolve;
 import edu.clemson.resolve.parser.ResolveBaseListener;
+import edu.clemson.resolve.parser.ResolveBaseVisitor;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.rsrg.semantics.programtype.PTType;
 
+/** Uses a combination of listeners and visitors to check for some semantic
+ *  errors uncheckable in the grammar and ommited by {@link PopulatingVisitor}.
+ */
 public class SanityCheckingListener extends ResolveBaseListener {
+
+    private final RESOLVECompiler compiler;
+    private final AnnotatedTree tr;
+    public SanityCheckingListener(RESOLVECompiler rc, AnnotatedTree tr) {
+        this.compiler = rc;
+        this.tr = tr;
+    }
+
+    @Override public void exitConceptModule(Resolve.ConceptModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitEnhancementModule(
+            Resolve.EnhancementModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitFacilityModule(
+            Resolve.FacilityModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitConceptImplModule(
+            Resolve.ConceptImplModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitEnhancementImplModule(
+            Resolve.EnhancementImplModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitPrecisModule(Resolve.PrecisModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override public void exitProcedureDecl(Resolve.ProcedureDeclContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+        sanityCheckRecursiveProcKeyword(ctx, ctx.name, ctx.recursive);
+    }
+
+    @Override public void exitOperationProcedureDecl(
+            Resolve.OperationProcedureDeclContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+        sanityCheckRecursiveProcKeyword(ctx, ctx.name, ctx.recursive);
+    }
+
+    @Override public void exitAssignStmt(Resolve.AssignStmtContext ctx) {
+        //TODO: Also check that lhs is a variable based expr.
+        sanityCheckProgOpTypes(ctx,tr.progTypes.get(ctx.left),
+                tr.progTypes.get(ctx.right));
+    }
+
+    private void sanityCheckProgOpTypes(ParserRuleContext ctx,
+                                        PTType l, PTType r) {
+        if (!l.equals(r)) {
+            compiler.errMgr.semanticError(ErrorKind.INCOMPATIBLE_OP_TYPES,
+                    ctx.getStart(), ctx.getText(), l.toString(), r.toString());
+        }
+    }
+
+    private void sanityCheckRecursiveProcKeyword(ParserRuleContext ctx,
+                                                 Token name,
+                                                 Token recursiveToken) {
+        if (recursiveToken == null && hasRecursiveReference(ctx, name)) {
+            compiler.errMgr.semanticError(
+                    ErrorKind.UNLABELED_RECURSIVE_FUNC, name, name.getText(),
+                    name.getText());
+        }
+        else if (recursiveToken != null && !hasRecursiveReference(ctx, name)) {
+            compiler.errMgr.semanticError(
+                    ErrorKind.LABELED_NON_RECURSIVE_FUNC, name, name.getText());
+        }
+    }
+
+    private void sanityCheckBlockEnds(Token topName, Token bottomName) {
+        if (!topName.getText().equals(bottomName.getText())) {
+            compiler.errMgr.semanticError(
+                    ErrorKind.MISMATCHED_BLOCK_END_NAMES, bottomName,
+                    topName.getText(), bottomName.getText());
+        }
+    }
+
+    private boolean hasRecursiveReference(ParserRuleContext ctx, Token name) {
+        return new ResolveBaseVisitor<Void>() { public boolean foundRef = false;
+            @Override public Void visitProgParamExp(
+                    Resolve.ProgParamExpContext paramExp) {
+                foundRef = paramExp.name.getText().equals(name.getText());
+                return null;
+            }
+        }.foundRef;
+    }
+
 }

--- a/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
+++ b/compiler/src/edu/clemson/resolve/analysis/SanityCheckingListener.java
@@ -6,14 +6,19 @@ import edu.clemson.resolve.compiler.RESOLVECompiler;
 import edu.clemson.resolve.parser.Resolve;
 import edu.clemson.resolve.parser.ResolveBaseListener;
 import edu.clemson.resolve.parser.ResolveBaseVisitor;
+import edu.clemson.resolve.proving.absyn.PExp;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.rsrg.semantics.programtype.PTType;
 
-/** Uses a combination of listeners and visitors to check for some semantic
- *  errors uncheckable in the grammar and ommited by {@link PopulatingVisitor}.
+/**
+ * Uses a combination of listeners and visitors to check for some semantic
+ * errors uncheckable in the grammar and ommited by {@link PopulatingVisitor}.
+ * <p>
+ * To make many of our checks here easier, we make sure to have already built
+ * the ast for exprs in a previous phase.</p>
  */
 public class SanityCheckingListener extends ResolveBaseListener {
 
@@ -72,6 +77,16 @@ public class SanityCheckingListener extends ResolveBaseListener {
     @Override public void exitSwapStmt(Resolve.SwapStmtContext ctx) {
         sanityCheckProgOpTypes(ctx,tr.progTypes.get(ctx.left),
                 tr.progTypes.get(ctx.right));
+    }
+
+    @Override public void exitRequiresClause(Resolve.RequiresClauseContext ctx) {
+        PExp requires = tr.mathPExps.get(ctx);
+        if (requires != null && !requires.getIncomingVariables().isEmpty()) {
+            compiler.errMgr.semanticError(
+                    ErrorKind.ILLEGAL_INCOMING_REF_IN_REQUIRES, ctx.getStart(),
+                    requires.getIncomingVariables(),
+                    ctx.mathAssertionExp().getText());
+        }
     }
 
     private void sanityCheckProgOpTypes(ParserRuleContext ctx,

--- a/compiler/src/edu/clemson/resolve/codegen/ModelBuilder.java
+++ b/compiler/src/edu/clemson/resolve/codegen/ModelBuilder.java
@@ -576,8 +576,8 @@ public class ModelBuilder extends ResolveBaseListener {
     }
 
     protected CallStat buildPrimitiveInfixStat(String name,
-                                               Resolve.ProgExpContext left,
-                                               Resolve.ProgExpContext right) {
+                                               ParserRuleContext left,
+                                               ParserRuleContext right) {
         Qualifier.NormalQualifier qualifier = new NormalQualifier("RESOLVEBase");
         return new CallStat(qualifier, name, (Expr) built.get(left),
                 (Expr) built.get(right));

--- a/compiler/src/edu/clemson/resolve/codegen/ModelBuilder.java
+++ b/compiler/src/edu/clemson/resolve/codegen/ModelBuilder.java
@@ -244,13 +244,15 @@ public class ModelBuilder extends ResolveBaseListener {
             //If this is true, then we're likely dealing with a math definition
             //(which has no sensible prog type), so we ignore the rest of our
             //logic here
+            //Yes, kind of weird, but then again, so is passing defs as params...
             if (tr.progTypes.get(ctx.progExp()) == null) return;
 
             //Todo: I think it's ok to do getChild(0) here; we know we're
             //dealing with a VarNameRef (so our (2nd) child ctx must be progNamedExp)...
+            //Todo2: this line below is pretty fugly. Change me eventually.
             Resolve.ProgNamedExpContext argAsNamedExp =
                     (Resolve.ProgNamedExpContext) ctx.progExp()
-                            .getChild(0).getChild(0);
+                            .getChild(0).getChild(0).getChild(0);
             try {
                 OperationSymbol s =
                         moduleScope.queryForOne(
@@ -370,6 +372,10 @@ public class ModelBuilder extends ResolveBaseListener {
                 HardCodedProgOps.convert(op, argTypes);
         return new MethodCall(buildQualifier(o.qualifier, o.name),
                 o.name.getText(), Utils.collect(Expr.class, args, built));
+    }
+
+    @Override public void exitProgVarExp(Resolve.ProgVarExpContext ctx) {
+        built.put(ctx, built.get(ctx.getChild(0)));
     }
 
     @Override public void exitProgNamedExp(Resolve.ProgNamedExpContext ctx) {

--- a/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
+++ b/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
@@ -217,9 +217,9 @@ public enum ErrorKind {
     GENERATED_JAVA_ERROR(38, "generated java error: <arg>",
             ErrorSeverity.ERROR),
 
-    UNLABELED_RECURSIVE_FUNC(39, "recursive call <arg> to unmarked " +
-            "recursive procedure '<arg2>'; correct definition is: " +
-            "Oper <arg2>(..); Recursive Procedure' ... end <arg2>;",
+    UNLABELED_RECURSIVE_FUNC(39, "recursive call '<arg>' detected in an " +
+            "unmarked recursive procedure: '<arg2>'; should be: " +
+            "Oper <arg2>(..); Recursive Procedure ... end <arg2>;",
                          ErrorSeverity.WARNING),
 
     MISMATCHED_BLOCK_END_NAMES(40, "mismatched block end names: " +

--- a/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
+++ b/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
@@ -215,7 +215,12 @@ public enum ErrorKind {
      * Compiler Error 38: generated Java error: <em>message</em>.
      */
     GENERATED_JAVA_ERROR(38, "generated java error: <arg> ",
-            ErrorSeverity.ERROR);
+            ErrorSeverity.ERROR),
+
+    UNMARKED_RECURSIVE_CALL(39, "recursive call <arg> to unmarked " +
+            "recursive procedure '<arg2>'; correct definition is: " +
+            "Oper <arg2>(..); Recursive Procedure' ... end <arg2>;",
+                         ErrorSeverity.WARNING);
 
     /**
      * Compiler Warning 39: generated Java warning: <em>message</em>.

--- a/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
+++ b/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
@@ -232,6 +232,11 @@ public enum ErrorKind {
 
     INCOMPATIBLE_OP_TYPES(42, "incompatible types on <arg> found: " +
             "<arg2>, <arg3>; these need to be the same types",
+            ErrorSeverity.ERROR),
+
+    ILLEGAL_INCOMING_REF_IN_REQUIRES(42, "found illegal '@'-valued " +
+            "variable ref(s): [<arg; separator={, }>] in requires " +
+            "clause: <arg2>; '@-variables' are not permitted in requires clauses",
             ErrorSeverity.ERROR);
 
     public final int code;

--- a/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
+++ b/compiler/src/edu/clemson/resolve/compiler/ErrorKind.java
@@ -214,19 +214,25 @@ public enum ErrorKind {
     /**
      * Compiler Error 38: generated Java error: <em>message</em>.
      */
-    GENERATED_JAVA_ERROR(38, "generated java error: <arg> ",
+    GENERATED_JAVA_ERROR(38, "generated java error: <arg>",
             ErrorSeverity.ERROR),
 
-    UNMARKED_RECURSIVE_CALL(39, "recursive call <arg> to unmarked " +
+    UNLABELED_RECURSIVE_FUNC(39, "recursive call <arg> to unmarked " +
             "recursive procedure '<arg2>'; correct definition is: " +
             "Oper <arg2>(..); Recursive Procedure' ... end <arg2>;",
-                         ErrorSeverity.WARNING);
+                         ErrorSeverity.WARNING),
 
-    /**
-     * Compiler Warning 39: generated Java warning: <em>message</em>.
-     */
-    //GENERATED_JAVA_WARNING(39, "generated java warning: <arg> ",
-    //                     ErrorSeverity.WARNING);
+    MISMATCHED_BLOCK_END_NAMES(40, "mismatched block end names: " +
+            "'<arg>' != '<arg2>'",
+                            ErrorSeverity.WARNING),
+
+    LABELED_NON_RECURSIVE_FUNC(41, "procedure <arg> marked as recursive, " +
+            "but contains no recursive calls",
+            ErrorSeverity.WARNING),
+
+    INCOMPATIBLE_OP_TYPES(42, "incompatible types on <arg> found: " +
+            "<arg2>, <arg3>; these need to be the same types",
+            ErrorSeverity.ERROR);
 
     public final int code;
     public final String message;

--- a/compiler/src/edu/clemson/resolve/parser/Resolve.g4
+++ b/compiler/src/edu/clemson/resolve/parser/Resolve.g4
@@ -210,11 +210,11 @@ stmt
     ;
 
 assignStmt
-    :   left=progExp ASSIGN right=progExp SEMI
+    :   left=progVarExp ASSIGN right=progExp SEMI
     ;
 
 swapStmt
-    :   left=progExp SWAP right=progExp SEMI
+    :   left=progVarExp SWAP right=progVarExp SEMI
     ;
 
 //semantically restrict things like 1++ (<literal>++/--, etc)
@@ -522,8 +522,12 @@ progExp
 
 progPrimary
     :   progLiteralExp
-    |   progNamedExp
+    |   progVarExp
     |   progParamExp
+    ;
+
+progVarExp
+    :   progNamedExp
     |   progMemberExp
     ;
 

--- a/compiler/src/edu/clemson/resolve/parser/Resolve.g4
+++ b/compiler/src/edu/clemson/resolve/parser/Resolve.g4
@@ -367,11 +367,11 @@ operationDecl
     ;
 
 operationProcedureDecl
-    :   (recursive=RECURSIVE)? OPERATION
+    :   OPERATION
         name=ID operationParameterList (COLON type)? SEMI
         (requiresClause)?
         (ensuresClause)?
-        PROCEDURE
+        (recursive=RECURSIVE)? PROCEDURE
         (variableDeclGroup)*
         (stmt)*
         END closename=ID SEMI

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PAlternatives.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PAlternatives.java
@@ -121,7 +121,7 @@ public class PAlternatives extends PExp {
     }
 
     @Override public Set<PSymbol> getIncomingVariablesNoCache() {
-        Set<PSymbol> result = new HashSet<>();
+        Set<PSymbol> result = new LinkedHashSet<>();
 
         for (Alternative a : alternatives) {
             result.addAll(a.condition.getIncomingVariables());

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PExpBuildingListener.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PExpBuildingListener.java
@@ -295,6 +295,10 @@ public class PExpBuildingListener<T extends PExp> extends ResolveBaseListener {
         repo.put(ctx, repo.get(ctx.getChild(0)));
     }
 
+    @Override public void exitProgVarExp(Resolve.ProgVarExpContext ctx) {
+        repo.put(ctx, repo.get(ctx.getChild(0)));
+    }
+
     @Override public void exitProgNamedExp(Resolve.ProgNamedExpContext ctx) {
         PSymbolBuilder result = new PSymbolBuilder(ctx.name.getText()) //
                 .mathTypeValue(getMathTypeValue(ctx)) //

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PSet.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PSet.java
@@ -85,7 +85,7 @@ public class PSet extends PExp {
     }
 
     @Override public Set<PSymbol> getIncomingVariablesNoCache() {
-        return new HashSet<>();
+        return new LinkedHashSet<>();
     }
 
     @Override public Set<PSymbol> getQuantifiedVariablesNoCache() {

--- a/compiler/src/edu/clemson/resolve/proving/absyn/PSymbol.java
+++ b/compiler/src/edu/clemson/resolve/proving/absyn/PSymbol.java
@@ -473,7 +473,7 @@ public class PSymbol extends PExp {
     }
 
     @Override public Set<PSymbol> getIncomingVariablesNoCache() {
-        Set<PSymbol> result = new HashSet<>();
+        Set<PSymbol> result = new LinkedHashSet<>();
         if ( incomingFlag ) {
             if ( arguments.size() == 0 ) {
                 result.add(this);

--- a/compiler/src/org/rsrg/semantics/query/ResultProcessingQuery.java
+++ b/compiler/src/org/rsrg/semantics/query/ResultProcessingQuery.java
@@ -32,8 +32,9 @@ public class ResultProcessingQuery<T extends Symbol, R extends Symbol>
 
     @Override public List<R> searchFromContext(Scope source, SymbolTable repo)
             throws DuplicateSymbolException {
-        return baseQuery.searchFromContext(source, repo).stream()
+        List<R> processedList = baseQuery.searchFromContext(source, repo).stream()
                 .map(mapping::apply)
                 .collect(Collectors.toList());
+        return processedList ;
     }
 }

--- a/compiler/src/org/rsrg/semantics/symbol/OperationSymbol.java
+++ b/compiler/src/org/rsrg/semantics/symbol/OperationSymbol.java
@@ -62,6 +62,10 @@ public class OperationSymbol
         return this;
     }
 
+    @Override public ProgVariableSymbol toProgVariableSymbol() {
+        return new ProgVariableSymbol(name, definingTree, returnType, moduleID);
+    }
+
     @Override public String getSymbolDescription() {
         return "an operation";
     }

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,6 +1,9 @@
  Facility T; uses Standard_Integers, Standard_Char_Strings;
      Operation Main ();
-         Procedure
+         Recursive Procedure
+            Var x : Std_Char_Str_Fac :: Char_Str;
+            Var y : Std_Integer_Fac :: Integer;
+            y := x;
              Main();
-     end Main;
-end T;
+     end Man;
+end Tao;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,6 +1,7 @@
- Facility T; uses Standard_Integers, Standard_Char_Strings;
-
-    Operation Main();
-        Recursive Procedure
+ Facility T;
+        uses Standard_Integers, Standard_Char_Strings, Basic_Integer_Theory;
+    Operation Main(evaluates x : Std_Integer_Fac :: Integer);
+            requires @x + x;
+        Procedure
     end Main;
 end T;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,6 +1,12 @@
  Facility T; uses Standard_Integers, Standard_Char_Strings;
-     Operation Main ();
-         Recursive Procedure
-             Main();
-     end Main;
+     Operation Prefix_Dog_with (alters prefix : Std_Char_Str_Fac :: Char_Str) :
+             Std_Char_Str_Fac :: Char_Str;
+      Procedure Prefix_Dog_with:=prefix++"Dog"; end Prefix_Dog_with;
+
+
+       Operation Main();
+         Procedure Var x: Std_Char_Str_Fac :: Char_Str;
+                x:="cat"; x:=Prefix_Dog_with(x);
+                Std_Char_Str_Fac :: Write_Line(x);
+        end Main;
 end T;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,12 +1,6 @@
  Facility T; uses Standard_Integers, Standard_Char_Strings;
-     Operation Prefix_Dog_with (alters prefix : Std_Char_Str_Fac :: Char_Str) :
-             Std_Char_Str_Fac :: Char_Str;
-      Procedure Prefix_Dog_with:=prefix++"Dog"; end Foo;
-
-
-       Operation Main();
-         Procedure Var x: Std_Char_Str_Fac :: Char_Str;
-                x:="cat"; x:=Prefix_Dog_with(x);
-                Std_Char_Str_Fac :: Write_Line(x);
-        end Main;
+     Operation Main ();
+         Procedure
+             Main();
+     end Main;
 end T;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,9 +1,6 @@
  Facility T; uses Standard_Integers, Standard_Char_Strings;
      Operation Main ();
          Recursive Procedure
-            Var x : Std_Char_Str_Fac :: Char_Str;
-            Var y : Std_Integer_Fac :: Integer;
-            y := x;
              Main();
-     end Man;
-end Tao;
+     end Main;
+end T;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,12 +1,6 @@
  Facility T; uses Standard_Integers, Standard_Char_Strings;
-     Operation Prefix_Dog_with (alters prefix : Std_Char_Str_Fac :: Char_Str) :
-             Std_Char_Str_Fac :: Char_Str;
-      Procedure Prefix_Dog_with:=prefix++"Dog"; end Prefix_Dog_with;
 
-
-       Operation Main();
-         Procedure Var x: Std_Char_Str_Fac :: Char_Str;
-                x:="cat"; x:=Prefix_Dog_with(x);
-                Std_Char_Str_Fac :: Write_Line(x);
-        end Main;
+    Operation Main();
+        Recursive Procedure
+    end Main;
 end T;

--- a/compiler/workspace/T.resolve
+++ b/compiler/workspace/T.resolve
@@ -1,5 +1,12 @@
-Concept T<U>(evaluates i,j,k : Std_Integer_Fac :: Integer;
-        Definition Is_LEQ(i,j : U) : B;);
-            uses Standard_Booleans, Standard_Integers;
-    Operation Op(evaluates i, j : U);
+ Facility T; uses Standard_Integers, Standard_Char_Strings;
+     Operation Prefix_Dog_with (alters prefix : Std_Char_Str_Fac :: Char_Str) :
+             Std_Char_Str_Fac :: Char_Str;
+      Procedure Prefix_Dog_with:=prefix++"Dog"; end Foo;
+
+
+       Operation Main();
+         Procedure Var x: Std_Char_Str_Fac :: Char_Str;
+                x:="cat"; x:=Prefix_Dog_with(x);
+                Std_Char_Str_Fac :: Write_Line(x);
+        end Main;
 end T;

--- a/compiler/workspace/U.resolve
+++ b/compiler/workspace/U.resolve
@@ -1,12 +1,7 @@
 Facility U;
-        uses Standard_Booleans, Standard_Char_Strings;
+     
     Operation Main ();
         Procedure
-            Var x, u : Std_Char_Str_Fac :: Char_Str;
-            Var y, z : Std_Boolean_Fac :: Boolean;
-            x:="cat";
-            u:="dog";
-            Std_Char_Str_Fac :: Write_Line(x++u);
-
+            Main();
     end Main;
 end U;


### PR DESCRIPTION
Addresses #31 and gives #35 a start. This also includes a notable change to program expression hierarchy that clumps member access exps and named variable exps under the common root rule `progVarExp`. Changes were made the in the appropriate places throughout the compiler to accomodate this tweak.